### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"         : "6.c",
     "name"         : "Test::When",
+    "license"      : "Artistic-2.0",
     "version"      : "1.001005",
     "description"  : "Selectively run tests based on the environment and installed modules and libs",
     "depends"      : [ ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license