### PR TITLE
Match invalid keyword error by message, not exact stderr

### DIFF
--- a/t/01-env-vars.rakutest
+++ b/t/01-env-vars.rakutest
@@ -126,14 +126,14 @@ subtest {
 
 subtest {
     my $test = 't/tests/08-env-invalid-keyword.txt';
-    is run-test($test),
-        " STDERR: ===SORRY!===\nPositional arguments to Test::When can only"
-        ~ " be author extended interactive online release smoke\n",
+    ok run-test($test).contains(
+        "Positional arguments to Test::When can only"
+        ~ " be author extended interactive online release smoke"),
         'without env vars';
 
-    is run-test($test, :ALL_TESTING),
-        " STDERR: ===SORRY!===\nPositional arguments to Test::When can only"
-        ~ " be author extended interactive online release smoke\n",
+    ok run-test($test, :ALL_TESTING).contains(
+        "Positional arguments to Test::When can only"
+        ~ " be author extended interactive online release smoke"),
         "with ALL_TESTING";
 }, 'running with invalid keyword for testing';
 


### PR DESCRIPTION
Under the RakuAST frontend the compiler prefixes a use time error with "Error while compiling <file>" and appends the source location, which the legacy frontend omits, so the exact stderr comparison failed there. Check that the diagnostic message is present instead.